### PR TITLE
Fix prediction reshape order

### DIFF
--- a/estimation/notsensor/makeEstimationWithPDF_Dense.ipynb
+++ b/estimation/notsensor/makeEstimationWithPDF_Dense.ipynb
@@ -120,7 +120,7 @@
     "        Y_pred = my_model(\n",
     "            torch.from_numpy(X_test).type(torch.FloatTensor))\n",
     "        Y_pred = Y_pred.cpu().detach().numpy()\n",
-    "        Y_pred = np.reshape(Y_pred, [3, -1])\n",
+    "        Y_pred = np.reshape(Y_pred, [3, -1], order="F")\n",
     "        Y_pred = np.transpose(Y_pred)\n",
     "        # Rescale data back to original size\n",
     "        Y_true_pick_afterscaler = (Y_true - load_scaler4Y.min_) / load_scaler4Y.scale_\n",


### PR DESCRIPTION
## Summary
- ensure predictions use Fortran order when reshaping in estimation notebook

## Testing
- `pytest` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68654eedc0c88331988ae1b9dba47ece